### PR TITLE
Switch ci system to travis from circle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ android:
   components:
     - android-23
     - build-tools-23.0.0
+    - extra-android-m2repository
 
 script:
   - ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: android
+android:
+  components:
+    - android-23
+    - build-tools-23.0.0
+
+script:
+  - ./gradlew test
+
+after_success:
+  - ./gradlew unitTestCoverage
+  - ./gradlew coveralls
+
+notifications:
+  slac:
+    secure: Rvf+6fB0RlaGsMgpnwn9DNpWXDxJua7LIey+HIYHuBu4+aWeXqhm4zWem7zrcHC3dldoga+RH63zGxckKfREqX+ONXD2xvwxgHgC3jJXeh0QSdF4t3KUZ/ZUPEPzsSztR+YTvgTTzmFzqBm46VGEKFt9RDBnQaiyD9/5PTXf59Fbz/+2NuqOvxwTXOj0FU2O//rHlmLYpgdsKvWWir6ZTnf6ZNpsqD6qYnnkUvG8abKNKpHVVSk0Pk7Yj14j7bAbTwPru1umP6PLQqU/WspjaZUoooTe9ziwsgQuCgnUuCBP5t8EObYsjyiUT1a35LPzqNJbHTfknh7x8h41xykRm+T9buNzCFkMnTGrkp6KM8KdFVy5cX29t5fY71UGPnwuukvj5ZHGwGvw8A2ftaYYWJKkRyYQemGIWMnHBcASYH+WtZ8J2iJ2B9j0E5CPxyVPzkZDzxlbC5FpjK97oFoXxHFfqO9EkMfvuS/q/Ql/fHm7grGGQWTzxFieQwbxhCAmhHnfZwlPBvtWXX1tYLWGpimHLraeiKtqfvTx4IQYI6yHkmu01m0Sx6ZU0/9LpcKJVFMvrr2BLBBrNUFFQqDu8IG/ArkBdN2OmFqZKt6WpUuCqdjnvuAu6ARSFoywr7lNOAkTRcRKqTfgDodaY9xINmANtLhoqKGHtKMWFlheYWU=

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-dependencies:
-  pre:
-    - echo y | android update sdk --no-ui --all --filter "android-23"
-    - echo y | android update sdk --no-ui --all --filter "build-tools-23.0.0"
-
-test:
-  post:
-    - ./gradlew unitTestCoverage
-    - ./gradlew coveralls


### PR DESCRIPTION
because I use [coveralls-gradle-plugin](https://github.com/kt3k/coveralls-gradle-plugin), however it cannot send detail information for coveralls.

I watch https://github.com/kt3k/coveralls-gradle-plugin/issues/47 : if any progress will be here, I reconsider use which ci system.
